### PR TITLE
Add a type index so that types work properly when installed via npm

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,3 @@
+/// <reference path="./src/globalThis.d.ts" />
+
+export * from "./src/mod";

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,3 +1,0 @@
-/// <reference path="./src/globalThis.d.ts" />
-
-export * from "./src/mod";

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "A reactive UI library for JavaScript and TypeScript.",
   "version": "0.6.0",
   "main": "./dist/examples/main.js",
-  "types": "./index.d.ts",
+  "types": "./src/mod.ts",
   "type": "module",
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^4.26.0",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "description": "A reactive UI library for JavaScript and TypeScript.",
   "version": "0.6.0",
   "main": "./dist/examples/main.js",
+  "types": "./index.d.ts",
   "type": "module",
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^4.26.0",

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -1,3 +1,5 @@
+/// <reference path="./globalThis.d.ts" />
+
 export { ReactivePrimitive         } from "./reactive/ReactivePrimitive.js";
 export { ReadonlyReactivePrimitive } from "./reactive/ReactivePrimitive.js";
 export { ReactiveArray             } from "./reactive/ReactiveArray/_ReactiveArray.js";

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -1,4 +1,5 @@
-import "./globalThis.d";
+// eslint-disable-next-line @typescript-eslint/triple-slash-reference
+/// <reference path="./globalThis.d.ts" />
 
 export { ReactivePrimitive         } from "./reactive/ReactivePrimitive.js";
 export { ReadonlyReactivePrimitive } from "./reactive/ReactivePrimitive.js";

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -1,4 +1,4 @@
-/// <reference path="./globalThis.d.ts" />
+import "./globalThis.d";
 
 export { ReactivePrimitive         } from "./reactive/ReactivePrimitive.js";
 export { ReadonlyReactivePrimitive } from "./reactive/ReactivePrimitive.js";


### PR DESCRIPTION
I'm not a particular fan of the /// <reference>, and it's explicitly discouraged by the TypeScript docs anyway. See [1]. However, I don't believe there's another option that makes this work, so 🤷🏻‍♀️.

[1]: https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html#-reference-path-